### PR TITLE
feat: blueprint agent with per-instance JWT-bearer auth

### DIFF
--- a/acme-hotel-website/script.js
+++ b/acme-hotel-website/script.js
@@ -1443,12 +1443,36 @@ function formatJwtClaims(claims) {
     return highlighted;
 }
 
+// Walks `sub` + nested `act.sub` claims (RFC 8693) into an ordered chain.
+// Returns e.g. ['john.doe@…', '<instance-uuid>', 'hotel-ai-agent'] or null.
+function extractActorChain(claims) {
+    if (!claims || !claims.sub || !claims.act) return null;
+    const chain = [claims.sub];
+    let current = claims.act;
+    while (current && current.sub) {
+        chain.push(current.sub);
+        current = current.act;
+    }
+    return chain.length > 1 ? chain : null;
+}
+
+function renderActorChainBadge(chain) {
+    // Subject first, then each actor up the delegation chain.
+    const labels = ['subject', 'actor', 'on behalf of'];
+    const pills = chain.map((sub, i) => {
+        const label = labels[Math.min(i, labels.length - 1)];
+        return `<span class="actor-pill"><span class="actor-pill-label">${escapeHtml(label)}</span><span class="actor-pill-sub">${escapeHtml(sub)}</span></span>`;
+    }).join('<span class="actor-arrow">→</span>');
+    return `<div class="actor-chain" title="RFC 8693 actor chain — read left to right as subject → actor → blueprint">${pills}</div>`;
+}
+
 function formatHeaders(headers) {
     if (!headers || Object.keys(headers).length === 0) {
         return '<div class="debug-code-block"><pre>No headers</pre></div>';
     }
 
     let jwtBlock = '';
+    let actorChainBlock = '';
     const formatted = Object.entries(headers)
         .map(([key, value]) => {
             const line = `${key}: ${value}`;
@@ -1457,7 +1481,10 @@ function formatHeaders(headers) {
                 const token = value.replace(/^Bearer\s+/i, '');
                 const claims = decodeJwt(token);
                 if (claims) {
-                    const uid = 'jwt-' + Math.random().toString(36).slice(2, 8);
+                    const chain = extractActorChain(claims);
+                    if (chain) {
+                        actorChainBlock = renderActorChainBadge(chain);
+                    }
                     jwtBlock = `
                         <button class="jwt-claims-toggle" onclick="this.classList.toggle('open');this.nextElementSibling.style.display=this.classList.contains('open')?'block':'none'">
                             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1470,17 +1497,27 @@ function formatHeaders(headers) {
         })
         .join('\n');
 
-    return `<div class="debug-code-block"><pre>${formatted}</pre>${jwtBlock}</div>`;
+    return `<div class="debug-code-block"><pre>${formatted}</pre>${actorChainBlock}${jwtBlock}</div>`;
 }
 
 function formatJson(data) {
     if (!data) {
         return '<div class="debug-code-block"><pre>No data</pre></div>';
     }
-    
+
     try {
         const formatted = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
-        return `<div class="debug-code-block"><pre>${escapeHtml(formatted)}</pre></div>`;
+        // If this looks like an OAuth token response, surface the actor chain
+        // from the access_token (RFC 8693 user → instance → blueprint).
+        let actorChainBlock = '';
+        if (data && typeof data === 'object' && typeof data.access_token === 'string') {
+            const claims = decodeJwt(data.access_token);
+            const chain = claims && extractActorChain(claims);
+            if (chain) {
+                actorChainBlock = renderActorChainBadge(chain);
+            }
+        }
+        return `<div class="debug-code-block"><pre>${escapeHtml(formatted)}</pre>${actorChainBlock}</div>`;
     } catch (e) {
         return `<div class="debug-code-block"><pre>Error formatting data: ${escapeHtml(String(data))}</pre></div>`;
     }

--- a/acme-hotel-website/styles.css
+++ b/acme-hotel-website/styles.css
@@ -1425,6 +1425,50 @@ body.inspector-resizing {
     border-radius: 4px;
 }
 
+/* RFC 8693 actor chain — subject → actor → blueprint, decoded from JWT */
+.actor-chain {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    padding: 8px 10px;
+    background: rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    border-radius: 5px;
+}
+
+.actor-pill {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 4px 8px;
+    background: rgba(99, 102, 241, 0.15);
+    border: 1px solid rgba(99, 102, 241, 0.3);
+    border-radius: 4px;
+    font-size: 0.7rem;
+    line-height: 1.2;
+}
+
+.actor-pill-label {
+    color: #a5b4fc;
+    font-weight: 600;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.actor-pill-sub {
+    color: #e0e7ff;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    word-break: break-all;
+}
+
+.actor-arrow {
+    color: #818cf8;
+    font-weight: 700;
+}
+
 /* JWT decoded claims */
 .jwt-claims-toggle {
     display: inline-flex;

--- a/agent-live-graph/public/app.js
+++ b/agent-live-graph/public/app.js
@@ -486,6 +486,18 @@
   detailModal.addEventListener('click', (e) => { if (e.target === detailModal) closeModal(); });
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeModal(); });
 
+  // Identity-token buttons open the token on jwt.io in a new tab. Delegated
+  // here so the handler covers dynamically rendered identity headers.
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.id-token-btn');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const token = btn.dataset.token;
+    if (!token) return;
+    window.open(`https://jwt.io/#token=${encodeURIComponent(token)}`, '_blank', 'noopener');
+  });
+
   /* ── Scroll helper ─────────────────────────────────────── */
   function scrollToBottom() {
     graphArea.scrollTo({ top: graphArea.scrollHeight, behavior: 'smooth' });
@@ -514,7 +526,78 @@
       timestamp: msg.timestamp || Date.now(),
       stats:     msg.stats || {},
       tags:      msg.tags || [],
+      identity:  msg.identity || null,
     };
+  }
+
+  /* Deterministic colour from a string — used to colour the instance pill
+   * so multiple agent instances pop visually side by side. */
+  function hashColour(str) {
+    let h = 0;
+    for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0;
+    // 137 is coprime with 360 and large enough that one-char differences in
+    // the input still produce widely separated hues.
+    return `hsl(${(h * 137) % 360}, 70%, 55%)`;
+  }
+
+  function shortInstance(id) {
+    if (!id) return '';
+    const m = id.match(/[0-9a-f]{8}/i);
+    return m ? id.slice(0, id.indexOf(m[0]) + 8) : (id.length > 20 ? id.slice(0, 20) + '…' : id);
+  }
+
+  function renderIdentityHeader(identity) {
+    if (!identity) return '';
+    const isDelegated = identity.profile && identity.profile.includes('hosted_delegated');
+    const cards = [];
+    if (identity.user) {
+      cards.push(`
+        <div class="id-card" title="End user">
+          <div class="id-card-label"><i class="ph ph-user"></i> User</div>
+          <div class="id-card-value">${escapeHtml(identity.user)}</div>
+        </div>`);
+    }
+    if (identity.blueprint) {
+      cards.push(`
+        <div class="id-card" title="Blueprint application in AM">
+          <div class="id-card-label"><i class="ph ph-blueprint"></i> Blueprint</div>
+          <div class="id-card-value">${escapeHtml(identity.blueprint)}</div>
+        </div>`);
+    }
+    if (identity.instance) {
+      const c = hashColour(identity.instance);
+      cards.push(`
+        <div class="id-card id-card-instance" title="Agent instance: ${escapeHtml(identity.instance)}" style="border-left:3px solid ${c}">
+          <div class="id-card-label"><i class="ph ph-circuitry"></i> Agent instance</div>
+          <div class="id-card-value" style="color:${c}">${escapeHtml(identity.instance)}</div>
+        </div>`);
+    }
+    if (!cards.length) return '';
+    const tag = isDelegated
+      ? '<span class="id-tag" title="RFC 8693 delegated token — agent acting on behalf of user">DELEGATED</span>'
+      : '<span class="id-tag id-tag-plain" title="Plain user OIDC token (no delegation)">USER TOKEN</span>';
+    const tokenButtons = [];
+    if (identity.rawUser) {
+      tokenButtons.push(`<button class="id-token-btn" data-token="${escapeHtml(identity.rawUser)}" title="Open user OIDC token in jwt.io"><i class="ph ph-user"></i> View user token</button>`);
+    }
+    if (identity.rawDelegated) {
+      tokenButtons.push(`<button class="id-token-btn id-token-btn-delegated" data-token="${escapeHtml(identity.rawDelegated)}" title="Open delegated token in jwt.io"><i class="ph ph-shield-check"></i> View delegated token</button>`);
+    }
+    const tokens = tokenButtons.length
+      ? `<div class="id-header-tokens">${tokenButtons.join('')}</div>`
+      : '';
+    return `
+      <div class="id-header">
+        <div class="id-header-row">
+          <div class="id-header-title">
+            <i class="ph ph-shield-check"></i>
+            <span>Identity chain</span>
+            ${tag}
+          </div>
+          ${tokens}
+        </div>
+        <div class="id-header-cards">${cards.join('<div class="id-card-arrow">›</div>')}</div>
+      </div>`;
   }
 
   function formatTime(ts) {
@@ -682,6 +765,8 @@
 
     // Render all steps inside the flow body
     const flowBody = wrapper.querySelector('.flow-body');
+    const idHeader = renderIdentityHeader(summary.identity);
+    if (idHeader) flowBody.insertAdjacentHTML('afterbegin', idHeader);
     currentGroup = null;
     for (const step of steps) {
       appendStep(step, flowBody);

--- a/agent-live-graph/public/styles.css
+++ b/agent-live-graph/public/styles.css
@@ -638,6 +638,136 @@ main {
   flex-shrink: 0;
 }
 
+/* Identity chain subheader — shown at the top of an expanded flow */
+.id-header {
+  margin: 0 0 12px 0;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.id-header-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+.id-header-title i {
+  font-size: 13px;
+  color: rgb(120, 220, 170);
+}
+.id-header-cards {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.id-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.id-card-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-3);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.id-card-label i { font-size: 11px; }
+.id-card-value {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.id-card-arrow {
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+  color: var(--text-3);
+  opacity: 0.5;
+  font-weight: 300;
+}
+.id-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 6px;
+  background: rgba(0, 200, 120, 0.15);
+  color: rgb(120, 220, 170);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  margin-left: 4px;
+}
+.id-tag-plain {
+  background: rgba(200, 200, 200, 0.1);
+  color: var(--text-3);
+}
+.id-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.id-header-tokens {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.id-token-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  color: var(--text-2);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.id-token-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: var(--text);
+}
+.id-token-btn i { font-size: 12px; }
+.id-token-btn-delegated {
+  border-color: rgba(0, 200, 120, 0.35);
+  color: rgb(140, 230, 180);
+}
+.id-token-btn-delegated:hover {
+  background: rgba(0, 200, 120, 0.12);
+  border-color: rgba(0, 200, 120, 0.5);
+}
+
 .flow-stat {
   display: inline-flex;
   align-items: center;

--- a/agent-live-graph/server.js
+++ b/agent-live-graph/server.js
@@ -233,6 +233,25 @@ const buffer = new TransactionBuffer({
       : outermost ? 'Complete Flow'
       : (innerEvents[0] || {}).apiName || '?';
 
+    // Identity for the flow: prefer the richest delegated chain we see across
+    // all events in the transaction (agent → MCP carries `act.sub`); fall back
+    // to the outermost (user OIDC token only). Keep both raw tokens so the UI
+    // can offer "View on jwt.io" for each.
+    const candidates = [outermost, ...innerEvents]
+      .map(e => e?.identity)
+      .filter(Boolean);
+    const delegated = candidates.find(i => i.instance);
+    const plainUser = candidates.find(i => !i.instance && i.user);
+    const flowIdentity = delegated
+      ? { ...delegated,
+          user: delegated.user || plainUser?.user || null,
+          rawDelegated: delegated.raw,
+          rawUser:      plainUser?.raw || null }
+      : (plainUser
+          ? { ...plainUser, rawUser: plainUser.raw, rawDelegated: null }
+          : null);
+    if (flowIdentity) delete flowIdentity.raw;
+
     ws.broadcast({
       type:      'live-steps',
       apiName:   flowName,
@@ -240,6 +259,7 @@ const buffer = new TransactionBuffer({
       steps:     allSteps,
       stats:     { mcpCalls, llmCalls, totalTokens },
       tags:      [...tags],
+      identity:  flowIdentity,
     });
   },
   onProgress(count) {
@@ -255,6 +275,42 @@ function isNoise(evt) {
   if (method === 'OPTIONS' || method === 'HEAD' || method === 'CONNECT') return true;
   if (evt.status === 499) return true;
   return false;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ * Identity extraction (display only — no signature verification)
+ *
+ * Pulls the Bearer JWT from the entrypoint request headers, decodes
+ * the claims, and shapes them into a user → instance → blueprint
+ * chain matching the RFC 8693 actor structure AM emits.
+ * ═══════════════════════════════════════════════════════════════ */
+function extractIdentity(log) {
+  const headers = (log.entrypointRequest || {}).headers
+               || (log.endpointRequest   || {}).headers;
+  if (!headers) return null;
+  const raw = headers['authorization'] || headers['Authorization'];
+  const val = Array.isArray(raw) ? raw[0] : raw;
+  if (!val || !val.startsWith('Bearer ')) return null;
+  const token = val.slice(7).trim();
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  let claims;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const pad = '='.repeat((4 - (b64.length % 4)) % 4);
+    claims = JSON.parse(Buffer.from(b64 + pad, 'base64').toString('utf8'));
+  } catch (_) { return null; }
+  const instance  = claims.act?.sub || null;
+  const blueprint = claims.act?.actor_act?.sub || claims.client_id || null;
+  // Skip non-delegated tokens — they have no useful chain to render.
+  if (!instance && !blueprint) return null;
+  return {
+    user:      claims.email || claims.sub || null,
+    instance,
+    blueprint,
+    profile:   claims.client_profile || null,
+    raw:       token,
+  };
 }
 
 /* ═══════════════════════════════════════════════════════════════
@@ -389,6 +445,11 @@ function processEvent(evt) {
     // Raw params for deferred classification at flush time
     _classifyParams: { evt, protocol },
   };
+
+  // Identity is extracted from every event — inner hops carry the delegated
+  // token (agent → MCP), outermost carries only the user's OIDC token. We
+  // pick the richest chain at flush time.
+  entry.identity = extractIdentity(log);
 
   if (isOutermost) {
     entry.userText    = protocol.details.userText || null;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,6 +392,9 @@ services:
       # Common configuration
       - ORGANIZATION=DEFAULT
       - ENVIRONMENT=DEFAULT
+    volumes:
+      # Shared with hotel-agent: blueprint agent private signing key.
+      - agent-keys:/agent-keys
     networks:
       - southbound
 
@@ -477,11 +480,6 @@ services:
       context: .
       dockerfile: ./hotel-agent/Dockerfile
     container_name: hotel-agent
-    depends_on:
-      acme-hotel-api:
-        condition: service_healthy
-      apim-gateway:
-        condition: service_healthy
     environment:
       - LLM_BASE_URL=http://gio-apim-gateway:8082/llm-proxy
       - LLM_MODEL=ollama:qwen3:0.6b
@@ -490,9 +488,60 @@ services:
       - AGENT_SERVER_PORT=8001
       - AM_TOKEN_URL=http://gio-am-gateway:8092/gravitee/oauth/token
       - AM_CLIENT_ID=hotel-ai-agent
-      - AM_CLIENT_SECRET=hotel-ai-agent
+      # Blueprint Agent (HOSTED_DELEGATED) — instances authenticate with a
+      # jwt-bearer assertion signed by the key written by gravitee-init.
+      - AGENT_PRIVATE_KEY_PATH=/agent-keys/agent-private.pem
+      - AGENT_KID=agent-key-prod
+      - AGENT_INSTANCE_ID=hotel-agent-instance-a
+      # Demo switch: set to "false" to omit actor_token from the RFC 8693
+      # exchange — AM then treats the request as impersonation and rejects it.
+      - INCLUDE_ACTOR_TOKEN=${INCLUDE_ACTOR_TOKEN:-true}
+    depends_on:
+      acme-hotel-api:
+        condition: service_healthy
+      apim-gateway:
+        condition: service_healthy
+      gravitee-init:
+        condition: service_completed_successfully
+    volumes:
+      - agent-keys:/agent-keys:ro
     ports:
       - "8001:8001"
+    restart: unless-stopped
+    networks:
+      - southbound
+
+  # Second instance of the same Blueprint Agent. Same image, same blueprint
+  # client_id and signing key — distinct AGENT_INSTANCE_ID so its delegated
+  # tokens carry a different `act.sub`. APIM round-robins between the two
+  # instances so the inspector visibly alternates which agent handled each
+  # request.
+  hotel-agent-2:
+    build:
+      context: .
+      dockerfile: ./hotel-agent/Dockerfile
+    container_name: hotel-agent-2
+    environment:
+      - LLM_BASE_URL=http://gio-apim-gateway:8082/llm-proxy
+      - LLM_MODEL=ollama:qwen3:0.6b
+      - LLM_TEMPERATURE=0.3
+      - MCP_HTTP_URLS=http://gio-apim-gateway:8082/hotels/mcp
+      - AGENT_SERVER_PORT=8001
+      - AM_TOKEN_URL=http://gio-am-gateway:8092/gravitee/oauth/token
+      - AM_CLIENT_ID=hotel-ai-agent
+      - AGENT_PRIVATE_KEY_PATH=/agent-keys/agent-private.pem
+      - AGENT_KID=agent-key-prod
+      - AGENT_INSTANCE_ID=hotel-agent-instance-b
+      - INCLUDE_ACTOR_TOKEN=${INCLUDE_ACTOR_TOKEN:-true}
+    depends_on:
+      acme-hotel-api:
+        condition: service_healthy
+      apim-gateway:
+        condition: service_healthy
+      gravitee-init:
+        condition: service_completed_successfully
+    volumes:
+      - agent-keys:/agent-keys:ro
     restart: unless-stopped
     networks:
       - southbound
@@ -574,6 +623,8 @@ volumes:
   ollama_data:
     driver: local
   openfga_postgres_data:
+    driver: local
+  agent-keys:
     driver: local
 
 networks:

--- a/gravitee-init/Dockerfile
+++ b/gravitee-init/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY main.py am_init.py apim_init.py ./
+COPY main.py am_init.py apim_init.py agent_keys.py ./
 COPY am-apps/ ./am-apps/
 COPY am-mcp-servers/ ./am-mcp-servers/
 COPY apim-apis/ ./apim-apis/

--- a/gravitee-init/agent_keys.py
+++ b/gravitee-init/agent_keys.py
@@ -1,0 +1,56 @@
+"""Generate the EC keypair used by HOSTED_DELEGATED agent instances.
+
+The private PEM lands on a shared volume that the hotel-agent container
+mounts read-only. The public JWK is returned so it can be PATCHed onto
+the blueprint application's `settings.oauth.jwks`.
+"""
+
+import os
+from typing import Any, Dict
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+
+
+def _int_to_base64url(value: int, length: int) -> str:
+    import base64
+    return base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode("ascii")
+
+
+def _public_key_to_jwk(public_key: EllipticCurvePublicKey, kid: str) -> Dict[str, Any]:
+    numbers = public_key.public_numbers()
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _int_to_base64url(numbers.x, 32),
+        "y": _int_to_base64url(numbers.y, 32),
+        "kid": kid,
+        "use": "sig",
+        "alg": "ES256",
+    }
+
+
+def ensure_agent_keypair(private_pem_path: str, kid: str) -> Dict[str, Any]:
+    """Generate an EC P-256 keypair if one doesn't already exist on disk.
+
+    Writes the PEM to *private_pem_path* (creating parent dirs) and returns
+    the matching public JWK Set ready for `settings.oauth.jwks`.
+    """
+    os.makedirs(os.path.dirname(private_pem_path), exist_ok=True)
+
+    if os.path.exists(private_pem_path):
+        with open(private_pem_path, "rb") as fh:
+            private_key = serialization.load_pem_private_key(fh.read(), password=None)
+    else:
+        private_key = ec.generate_private_key(ec.SECP256R1())
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        with open(private_pem_path, "wb") as fh:
+            fh.write(pem)
+        os.chmod(private_pem_path, 0o644)
+
+    return {"keys": [_public_key_to_jwk(private_key.public_key(), kid)]}

--- a/gravitee-init/am-apps/hotel-ai-agent.yaml
+++ b/gravitee-init/am-apps/hotel-ai-agent.yaml
@@ -1,16 +1,31 @@
-# Hotels AI Agent — Token Exchange (RFC 8693)
+# Hotels AI Agent — Blueprint Agent (HOSTED_DELEGATED)
+#
+# Registered as a real AGENT application. Each running hotel-agent instance
+# proves itself at the token endpoint with a signed jwt-bearer assertion
+# (RFC 7523) instead of sharing a static client_secret. The matching public
+# JWK is written into settings.oauth.jwks by gravitee-init at startup.
 name: "Hotels AI Agent"
 description: "Hotels AI Agent App"
-type: "SERVICE"
+type: "AGENT"
+kind: "HOSTED_DELEGATED"
 
 clientId: "hotel-ai-agent"
-clientSecret: "hotel-ai-agent"
+
+redirectUris:
+  - "http://localhost:8001/callback"
+
+# Generates an EC P-256 keypair on the shared agent-keys volume, then publishes
+# the public half on settings.oauth.jwks during the standard application PATCH.
+agentKeys:
+  privateKeyPath: "/agent-keys/agent-private.pem"
+  kid: "agent-key-prod"
 
 oauth:
   grantTypes:
-    - "urn:ietf:params:oauth:grant-type:token-exchange"
+    - "authorization_code"
     - "client_credentials"
-  tokenEndpointAuthMethod: "client_secret_basic"
+    - "urn:ietf:params:oauth:grant-type:token-exchange"
+  tokenEndpointAuthMethod: "private_key_jwt"
   pkce: false
   tokenExchange:
     inherited: true

--- a/gravitee-init/am_init.py
+++ b/gravitee-init/am_init.py
@@ -17,6 +17,8 @@ from typing import Optional, Dict, Any, List
 import requests
 import yaml
 
+from agent_keys import ensure_agent_keypair
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -307,22 +309,40 @@ class GraviteeInitializer:
             for c in claims
         ] if claims else []
 
+        # Blueprint Agent JWKS — for HOSTED_DELEGATED / AUTONOMOUS jwt-bearer auth.
+        # `agentKeys` generates an EC keypair on the shared volume and publishes
+        # the public JWK Set on settings.oauth.jwks.
+        agent_keys_cfg = app_config.get("agentKeys")
+        if agent_keys_cfg:
+            jwks = ensure_agent_keypair(
+                private_pem_path=agent_keys_cfg["privateKeyPath"],
+                kid=agent_keys_cfg.get("kid", "agent-key-prod"),
+            )
+            settings["jwks"] = jwks
+
         return {"settings": {"oauth": settings}}
 
     def create_application(self, app_config: Dict[str, Any]) -> Optional[str]:
         app_name = app_config["name"]
         client_id = app_config["clientId"]
         app_type = app_config.get("type", "BROWSER")
+        kind = app_config.get("kind")
 
-        self.log(f"Creating application '{app_name}' (type: {app_type})...")
+        self.log(f"Creating application '{app_name}' (type: {app_type}{', kind: ' + kind if kind else ''})...")
 
         payload: Dict[str, Any] = {
             "name": app_name,
             "type": app_type,
             "clientId": client_id,
-            "clientSecret": app_config.get("clientSecret"),
             "redirectUris": app_config.get("redirectUris", []),
         }
+        # AGENT applications: persona lives on top-level `kind`; AM derives the
+        # underlying client defaults from it. No clientSecret for HOSTED_DELEGATED
+        # when authenticating via jwt-bearer assertions.
+        if kind:
+            payload["kind"] = kind
+        if app_type != "AGENT" and app_config.get("clientSecret"):
+            payload["clientSecret"] = app_config["clientSecret"]
         if app_config.get("description"):
             payload["description"] = app_config["description"]
         if app_config.get("agentCardUrl"):
@@ -388,8 +408,31 @@ class GraviteeInitializer:
         try:
             r = self.session.patch(self._app_url(app_id), json=payload, timeout=10)
             r.raise_for_status()
-            grants = r.json().get("settings", {}).get("oauth", {}).get("grantTypes", [])
+            saved = r.json().get("settings", {}).get("oauth", {})
+            grants = saved.get("grantTypes", [])
             self.log(f"  ✓ OAuth settings configured — grantTypes: {grants}")
+
+            # Verify private_key_jwt + JWKS landed (AM has been known to silently
+            # drop these when set in the same PATCH as other fields).
+            want_auth = payload["settings"]["oauth"].get("tokenEndpointAuthMethod")
+            want_jwks = payload["settings"]["oauth"].get("jwks")
+            needs_fix = {}
+            if want_auth and saved.get("tokenEndpointAuthMethod") != want_auth:
+                needs_fix["tokenEndpointAuthMethod"] = want_auth
+            if want_jwks and not saved.get("jwks", {}).get("keys"):
+                needs_fix["jwks"] = want_jwks
+            if needs_fix:
+                self.log(f"  ! Re-applying dropped fields: {list(needs_fix.keys())}")
+                r2 = self.session.patch(self._app_url(app_id), json={"settings": {"oauth": needs_fix}}, timeout=10)
+                r2.raise_for_status()
+                saved2 = r2.json().get("settings", {}).get("oauth", {})
+                if want_auth and saved2.get("tokenEndpointAuthMethod") != want_auth:
+                    self.log(f"  ERROR: tokenEndpointAuthMethod still not persisted (got {saved2.get('tokenEndpointAuthMethod')!r})")
+                    return False
+                if want_jwks and not saved2.get("jwks", {}).get("keys"):
+                    self.log("  ERROR: jwks still not persisted")
+                    return False
+                self.log("  ✓ Re-PATCH applied successfully")
             return True
         except requests.exceptions.RequestException as exc:
             self._log_response_error("Failed to configure settings", exc)

--- a/gravitee-init/apim-apis/ACME-Hotels-API-1-0.json
+++ b/gravitee-init/apim-apis/ACME-Hotels-API-1-0.json
@@ -274,7 +274,7 @@
                 "message": "Access denied: this endpoint requires a delegated access token issued to the AI Agent on behalf of an authenticated user.",
                 "statusCode": 403
               },
-              "condition": "{#context.attributes['jwt.claims']['act']?.['sub'] != 'hotel-ai-agent' || #context.attributes['jwt.claims']['email'] == null}"
+              "condition": "{#context.attributes['jwt.claims']['client_profile'] == null || !#context.attributes['jwt.claims']['client_profile'].contains('ai_agent') || #context.attributes['jwt.claims']['email'] == null}"
             },
             {
               "name": "Transform Headers",

--- a/gravitee-init/apim-apis/Hotel-AI-Agent-1-0-0.json
+++ b/gravitee-init/apim-apis/Hotel-AI-Agent-1-0-0.json
@@ -61,6 +61,19 @@
             "services": {},
             "secondary": false,
             "tenants": []
+          },
+          {
+            "name": "Hotel Agent Proxy 2",
+            "type": "a2a-proxy",
+            "weight": 1,
+            "inheritConfiguration": true,
+            "configuration": {
+              "target": "http://hotel-agent-2:8001"
+            },
+            "sharedConfigurationOverride": "{}",
+            "services": {},
+            "secondary": false,
+            "tenants": []
           }
         ],
         "services": {}

--- a/gravitee-init/requirements.txt
+++ b/gravitee-init/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.33.1
 pyyaml==6.0.3
+cryptography==45.0.5

--- a/hotel-agent/agent/auth_service.py
+++ b/hotel-agent/agent/auth_service.py
@@ -1,15 +1,36 @@
-"""Authentication service using OAuth 2.0 Token Exchange (RFC 8693) with delegation."""
-import base64
+"""Blueprint Agent authentication.
+
+This agent is registered in Gravitee AM as a HOSTED_DELEGATED Blueprint
+Agent application. Each running instance proves itself at the token
+endpoint with a `jwt-bearer` client assertion (RFC 7523), signed with a
+private key loaded from a shared volume. The matching public JWK lives
+on the blueprint's `settings.oauth.jwks`.
+
+The minted access token's `act` claim records the blueprint as the
+actor, and a subsequent RFC 8693 token exchange adds the user as the
+subject — producing a `user → instance → blueprint` actor chain that
+downstream services can audit.
+"""
+import os
 import time
+import uuid
 from typing import Optional
 
 import httpx
+import jwt
 
 from agent.logger import get_agent_logger
 
 logger = get_agent_logger(__name__)
 
 TOKEN_EXPIRY_MARGIN_SECS = 30
+ASSERTION_VALIDITY_SECS = 300
+
+# Demo switch: when false, the token exchange request omits actor_token, so AM
+# treats it as impersonation rather than delegation. With the blueprint app
+# configured allowImpersonation=false/allowDelegation=true, AM rejects it —
+# useful for showing the difference between the two modes.
+INCLUDE_ACTOR_TOKEN = os.getenv("INCLUDE_ACTOR_TOKEN", "true").lower() == "true"
 
 
 class AuthenticationError(Exception):
@@ -19,19 +40,27 @@ class AuthenticationError(Exception):
 class AuthService:
     """Manages agent token lifecycle and RFC 8693 token exchange (delegation).
 
-    - Agent token obtained via client_credentials, auto-refreshed before expiry.
+    - Per-call `jwt-bearer` client assertions authenticate this instance to AM.
+    - Agent token obtained via `client_credentials`, auto-refreshed before expiry.
     - User requests trigger token exchange: user token (subject) + agent token (actor)
-      → delegated token with `act` claim.
+      → delegated token whose nested `act` chain carries instance + blueprint.
     """
 
-    def __init__(self, am_token_url: str, am_client_id: str, am_client_secret: str):
+    def __init__(
+        self,
+        am_token_url: str,
+        am_client_id: str,
+        private_key_path: str,
+        kid: str,
+        instance_id: Optional[str] = None,
+    ):
         self.am_token_url = am_token_url
         self.am_client_id = am_client_id
-        self.am_client_secret = am_client_secret
+        self.kid = kid
+        self.instance_id = instance_id or f"hotel-agent-{uuid.uuid4()}"
+        self._private_key_pem: Optional[bytes] = None
+        self._private_key_path = private_key_path
         self._http_client = httpx.AsyncClient(timeout=30.0)
-        self._basic_auth = base64.b64encode(
-            f"{am_client_id}:{am_client_secret}".encode()
-        ).decode()
         self._agent_token: Optional[str] = None
         self._agent_token_expires_at: float = 0
 
@@ -42,10 +71,48 @@ class AuthService:
     def _is_agent_token_expired(self) -> bool:
         return time.time() >= (self._agent_token_expires_at - TOKEN_EXPIRY_MARGIN_SECS)
 
+    def _load_private_key(self) -> bytes:
+        if self._private_key_pem is None:
+            with open(self._private_key_path, "rb") as fh:
+                self._private_key_pem = fh.read()
+        return self._private_key_pem
+
+    def _build_client_assertion(self) -> str:
+        """Sign a fresh jwt-bearer client assertion for this instance.
+
+        `iss != sub` tells AM this is agent-shaped (per blueprint-agents flow),
+        so it resolves the blueprint by `iss` and verifies against its JWKS.
+        """
+        now = int(time.time())
+        claims = {
+            "iss": self.am_client_id,           # blueprint client_id
+            "sub": self.instance_id,            # this running instance
+            "aud": self.am_token_url,
+            "iat": now,
+            "exp": now + ASSERTION_VALIDITY_SECS,
+            "jti": str(uuid.uuid4()),
+        }
+        return jwt.encode(
+            claims,
+            self._load_private_key(),
+            algorithm="ES256",
+            headers={"kid": self.kid},
+        )
+
+    def _token_endpoint_data(self, extra: dict) -> dict:
+        return {
+            **extra,
+            "client_id": self.am_client_id,
+            "client_assertion_type": "urn:gravitee:params:oauth:client-assertion-type:agent-jwt-bearer",
+            "client_assertion": self._build_client_assertion(),
+        }
+
     async def initialize(self):
-        logger.info(f"AuthService initializing (endpoint: {self.am_token_url})")
+        logger.info(
+            f"AuthService initializing — instance={self.instance_id} kid={self.kid} endpoint={self.am_token_url}"
+        )
         await self._refresh_agent_token()
-        logger.info("AuthService ready — agent token acquired")
+        logger.info("AuthService ready — agent token acquired via jwt-bearer assertion")
 
     async def ensure_agent_token(self) -> str:
         """Return a valid agent token, refreshing if expired."""
@@ -58,11 +125,8 @@ class AuthService:
         try:
             response = await self._http_client.post(
                 self.am_token_url,
-                data={"grant_type": "client_credentials"},
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Authorization": f"Basic {self._basic_auth}",
-                },
+                data=self._token_endpoint_data({"grant_type": "client_credentials"}),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
             response.raise_for_status()
             data = response.json()
@@ -84,24 +148,25 @@ class AuthService:
     async def exchange_token(self, subject_token: str) -> str:
         """Exchange a user token for a delegated token (RFC 8693).
 
-        Uses the agent's own token as actor_token, ensuring it's fresh.
+        subject_token=user token, actor_token=agent token — without actor_token
+        AM treats the request as impersonation rather than delegation.
         """
-        agent_token = await self.ensure_agent_token()
-
         try:
+            exchange_data = {
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "subject_token": subject_token,
+                "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            }
+            if INCLUDE_ACTOR_TOKEN:
+                agent_token = await self.ensure_agent_token()
+                exchange_data["actor_token"] = agent_token
+                exchange_data["actor_token_type"] = "urn:ietf:params:oauth:token-type:access_token"
+            else:
+                logger.warning("INCLUDE_ACTOR_TOKEN=false — exchanging without actor_token (impersonation; AM should reject)")
             response = await self._http_client.post(
                 self.am_token_url,
-                data={
-                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                    "subject_token": subject_token,
-                    "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                    "actor_token": agent_token,
-                    "actor_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                },
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Authorization": f"Basic {self._basic_auth}",
-                },
+                data=self._token_endpoint_data(exchange_data),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
             response.raise_for_status()
 

--- a/hotel-agent/agent/main.py
+++ b/hotel-agent/agent/main.py
@@ -46,7 +46,10 @@ AGENT_DESCRIPTION = os.getenv(
 MCP_HTTP_URLS = os.getenv("MCP_HTTP_URLS", os.getenv("MCP_HTTP_URL", ""))
 AM_TOKEN_URL = os.getenv("AM_TOKEN_URL", "")
 AM_CLIENT_ID = os.getenv("AM_CLIENT_ID", "")
-AM_CLIENT_SECRET = os.getenv("AM_CLIENT_SECRET", "")
+# Blueprint Agent — per-instance jwt-bearer assertion auth (RFC 7523)
+AGENT_PRIVATE_KEY_PATH = os.getenv("AGENT_PRIVATE_KEY_PATH", "/agent-keys/agent-private.pem")
+AGENT_KID = os.getenv("AGENT_KID", "agent-key-prod")
+AGENT_INSTANCE_ID = os.getenv("AGENT_INSTANCE_ID")  # default uuid generated in AuthService
 SYSTEM_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
     "You are a Hotel booking assistant. "
@@ -148,7 +151,13 @@ class MCPAgent:
     def __init__(self):
         self.mcp = MCPMultiClient(mcp_urls=MCP_HTTP_URLS, elicitation_callback=elicitation_mgr.request)
         self.llm = LLMClient()
-        self.auth = AuthService(am_token_url=AM_TOKEN_URL, am_client_id=AM_CLIENT_ID, am_client_secret=AM_CLIENT_SECRET)
+        self.auth = AuthService(
+            am_token_url=AM_TOKEN_URL,
+            am_client_id=AM_CLIENT_ID,
+            private_key_path=AGENT_PRIVATE_KEY_PATH,
+            kid=AGENT_KID,
+            instance_id=AGENT_INSTANCE_ID,
+        )
         self._ready = False
 
     async def initialize(self):

--- a/hotel-agent/pyproject.toml
+++ b/hotel-agent/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "httpx==0.28.1",
   "uvicorn==0.45.0",
+  "PyJWT[crypto]==2.10.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Re-register the hotel AI agent as a HOSTED_DELEGATED Blueprint Agent in AM. Each running instance now authenticates with an ES256-signed RFC 7523 client assertion (kid + instance_id in sub) instead of a shared client_secret, producing a user -> instance -> blueprint actor chain on delegated tokens.

- gravitee-init generates the EC P-256 keypair on a shared volume and publishes the public JWK on settings.oauth.jwks
- second agent instance (hotel-agent-2) wired into APIM round-robin so the inspector visibly alternates between instances
- ACME Hotels policy condition keys off client_profile instead of a hard-coded act.sub, matching the new nested actor shape
- INCLUDE_ACTOR_TOKEN switch toggles delegation vs. impersonation for the demo
- inspector + website debug panel render the actor chain (user, instance, blueprint) and offer jwt.io links for both tokens